### PR TITLE
improv Specify cassandra proto version 3 instead of default

### DIFF
--- a/drivers/cassandra/cassandra.go
+++ b/drivers/cassandra/cassandra.go
@@ -49,6 +49,7 @@ func (cs *Cassandra) Init(args ...string) {
 	cluster := gocql.NewCluster(ipaddr)
 	cluster.Keyspace = keyspace
 	cluster.Consistency = gocql.Quorum
+	cluster.ProtoVersion = 3
 	if len(args) == 5 {
 		log.WithField("username", args[3]).
 			Debug("Passing username and password to Cassandra")


### PR DESCRIPTION
gocql used cassandra proto version 2 by default. version 3 has improvements re connection pool so setting to newer version.
