### PR TITLE
allow cluster config by letting init run without session

### DIFF
--- a/drivers/cassandra/cassandra.go
+++ b/drivers/cassandra/cassandra.go
@@ -67,7 +67,6 @@ func (cs *Cassandra) Init(args ...string) {
 	cluster := gocql.NewCluster(ipaddr)
 	cluster.Keyspace = keyspace
 	cluster.Consistency = gocql.Quorum
-	cluster.ProtoVersion = 3
 	if len(args) == 5 {
 		log.WithField("username", args[3]).
 			Debug("Passing username and password to Cassandra")


### PR DESCRIPTION
this allows configuring timeouts/protoversion though *gocql.ClusterConfig and setting the session
